### PR TITLE
11 - add missing super in graphit_errors.rb

### DIFF
--- a/lib/graphiti_errors.rb
+++ b/lib/graphiti_errors.rb
@@ -16,6 +16,7 @@ module GraphitiErrors
       end
 
       def self.inherited(subklass)
+        super
         subklass._errorable_registry = _errorable_registry.dup
       end
     end


### PR DESCRIPTION
Fixes: https://github.com/graphiti-api/graphiti_errors/issues/11 and probably fixes https://github.com/graphiti-api/graphiti_errors/issues/10