### PR TITLE
Remove .register_exception class method

### DIFF
--- a/lib/graphiti_errors.rb
+++ b/lib/graphiti_errors.rb
@@ -23,15 +23,6 @@ module GraphitiErrors
     klass._errorable_registry = {}
     klass.extend ClassMethods
 
-    if defined?(Graphiti::Errors::InvalidRequest)
-      klass.register_exception Graphiti::Errors::InvalidRequest,
-        handler: GraphitiErrors::InvalidRequest::ExceptionHandler
-    end
-
-    if defined?(Graphiti::Errors::ConflictRequest)
-      klass.register_exception Graphiti::Errors::ConflictRequest,
-        handler: GraphitiErrors::ConflictRequest::ExceptionHandler
-    end
   end
 
   def self.disable!
@@ -75,11 +66,6 @@ module GraphitiErrors
   end
 
   module ClassMethods
-    def register_exception(klass, options = {})
-      exception_klass = options[:handler] || default_exception_handler
-      _errorable_registry[klass] = exception_klass.new(options)
-    end
-
     def default_exception_handler
       GraphitiErrors::ExceptionHandler
     end

--- a/spec/integration/graphiti_errors_spec.rb
+++ b/spec/integration/graphiti_errors_spec.rb
@@ -28,14 +28,6 @@ end
 class ApplicationController < ActionController::Base
   include GraphitiErrors
 
-  register_exception CustomStatusError,  status: 301
-  register_exception CustomTitleError,   title: "My Title"
-  register_exception MessageTrueError,   message: true
-  register_exception MessageProcError,   message: ->(e) { e.class.name.upcase }
-  register_exception MetaProcError,      meta: ->(e) { {class_name: e.class.name.upcase} }
-  register_exception LogFalseError,      log: false
-  register_exception CustomHandlerError, handler: CustomErrorHandler
-
   rescue_from Exception do |e|
     handle_exception(e, show_raw_error: show_raw_error?)
   end
@@ -56,8 +48,6 @@ class PostsController < ApplicationController
 end
 
 class SpecialPostsController < PostsController
-  register_exception SpecialPostError, message: ->(e) { "special post" }
-
   def index
     GraphitiErrors.enable!
     raise SpecialPostError
@@ -119,179 +109,6 @@ RSpec.describe "graphiti_errorable", type: :controller do
     end
   end
 
-  context "when the error is registered" do
-    it "is registered" do
-      registered = controller.registered_exception?(CustomStatusError.new)
-      expect(registered).to eq true
-    end
-
-    context "with custom status" do
-      before do
-        raises(CustomStatusError, "some message")
-      end
-
-      it "returns correct status code" do
-        get :index
-        expect(response.status).to eq(301)
-        expect(error["status"]).to eq("301")
-        expect(error["code"]).to eq("moved_permanently")
-      end
-    end
-
-    context "with custom title" do
-      before do
-        raises(CustomTitleError, "some message")
-      end
-
-      it "returns correct title" do
-        get :index
-        expect(error["title"]).to eq("My Title")
-      end
-    end
-
-    context "with message == true" do
-      before do
-        raises(MessageTrueError, "some message")
-      end
-
-      it "shows error message thrown" do
-        get :index
-        expect(error["detail"]).to eq("some message")
-      end
-    end
-
-    context "with message as proc" do
-      before do
-        raises(MessageProcError, "some_error")
-      end
-
-      it "shows custom error detail" do
-        get :index
-        expect(error["detail"]).to eq("MESSAGEPROCERROR")
-      end
-    end
-
-    context "with meta as proc" do
-      before do
-        raises(MetaProcError, "some_error")
-      end
-
-      it "shows custom error detail" do
-        get :index
-        expect(error["meta"]).to match("class_name" => "METAPROCERROR")
-      end
-    end
-
-    context "with log: false" do
-      before do
-        expect(Rails.logger).to_not receive(:error)
-      end
-
-      it "does not log the error" do
-        raises(LogFalseError, "some_error")
-        get :index
-      end
-    end
-
-    context "with custom error handling class" do
-      before do
-        raises(CustomHandlerError, "some message")
-      end
-
-      it "returns status customized by that class" do
-        get :index
-        expect(response.status).to eq(302)
-        expect(error["status"]).to eq("302")
-        expect(error["code"]).to eq("found")
-      end
-    end
-
-    context "when a graphiti invalid request error" do
-      let(:errors_object) do
-        double(:errors, {
-          details: {
-            'data.attributes.foo': [
-              {error: :not_writable},
-              {error: :invalid},
-            ],
-            'included[0].attributes.bar': [
-              {error: :unknown_attribute},
-            ],
-          },
-          messages: {
-            'data.attributes.foo': [
-              "is not writable",
-              "is invalid",
-            ],
-            'included[0].attributes.bar': [
-              "is not a known attribute",
-            ],
-          },
-        }).tap do |d|
-          allow(d).to receive(:full_message)
-            .with(:'data.attributes.foo', "is not writable").and_return("not writable full message")
-          allow(d).to receive(:full_message)
-            .with(:'data.attributes.foo', "is invalid").and_return("invalid full message")
-          allow(d).to receive(:full_message)
-            .with(:'included[0].attributes.bar', "is not a known attribute").and_return("unknown attribute full message")
-        end
-      end
-
-      before do
-        raises(Graphiti::Errors::InvalidRequest, errors_object)
-      end
-
-      it "returns a bad request error payload" do
-        get :index
-        expect(response.status).to eq(400)
-        expect(json["errors"]).to eq([
-          {
-            "code" => "bad_request",
-            "detail" => "not writable full message",
-            "meta" => {
-              "attribute" => "data.attributes.foo",
-              "code" => "not_writable",
-              "message" => "is not writable",
-            },
-            "source" => {
-              "pointer" => "data/attributes/foo",
-            },
-            "status" => "400",
-            "title" => "Request Error",
-          },
-          {
-            "code" => "bad_request",
-            "detail" => "invalid full message",
-            "meta" => {
-              "attribute" => "data.attributes.foo",
-              "code" => "invalid",
-              "message" => "is invalid",
-            },
-            "source" => {
-              "pointer" => "data/attributes/foo",
-            },
-            "status" => "400",
-            "title" => "Request Error",
-          },
-          {
-            "code" => "bad_request",
-            "detail" => "unknown attribute full message",
-            "meta" => {
-              "attribute" => "included[0].attributes.bar",
-              "code" => "unknown_attribute",
-              "message" => "is not a known attribute",
-            },
-            "source" => {
-              "pointer" => "included/0/attributes/bar",
-            },
-            "status" => "400",
-            "title" => "Request Error",
-          },
-        ])
-      end
-    end
-  end
-
   if defined?(Graphiti::Errors::ConflictRequest)
     context "when a graphiti conflict request error" do
       let(:errors_object) do
@@ -342,15 +159,6 @@ RSpec.describe "graphiti_errorable", type: :controller do
       it "is not customized" do
         get :index, params: {error: "SpecialPostError"}
         expect(error["detail"]).to eq(standard_detail)
-      end
-    end
-
-    context "and subclass is hit with its registered error" do
-      controller(SpecialPostsController) { }
-
-      it "customizes response" do
-        get :index
-        expect(error["detail"]).to eq("special post")
       end
     end
   end


### PR DESCRIPTION
This functionality has been reimplemented in the rescue_registery gem.